### PR TITLE
修复一下权限问题

### DIFF
--- a/.github/workflows/Release Preparation.yml
+++ b/.github/workflows/Release Preparation.yml
@@ -7,6 +7,8 @@ jobs:
   prepare:
     name: 发布准备
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         shell: pwsh


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/Release Preparation.yml` file. The change grants write permissions to the `contents` scope for the `prepare` job in the release preparation workflow.

* [`.github/workflows/Release Preparation.yml`](diffhunk://#diff-198eeef61b721616bae0d196648f08d7904a02ee3edf3839ca476e067ff22805R10-R11): Added `permissions` field with `contents: write` to the `prepare` job.…ion workflow