### PR TITLE
fix(release): exclude pnpm-lock.yaml from git add in release preparat…

### DIFF
--- a/.github/workflows/Release Preparation.yml
+++ b/.github/workflows/Release Preparation.yml
@@ -50,7 +50,7 @@ jobs:
         run: node .github/scripts/updateChangelog.js --version=${{ env.VERSION }}
       - name: 更新提交
         run: |
-          git add .
+          git add . ':!pnpm-lock.yaml'
           git commit -m "chore: 更新版本号和更新日志 ${{ env.VERSION }}"
           git push origin HEAD
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/Release Preparation.yml` file. The change modifies the `git add` command to exclude the `pnpm-lock.yaml` file during the commit process.

* [`.github/workflows/Release Preparation.yml`](diffhunk://#diff-198eeef61b721616bae0d196648f08d7904a02ee3edf3839ca476e067ff22805L53-R53): Modified the `git add` command to exclude `pnpm-lock.yaml` during the commit process.…ion workflow